### PR TITLE
Fix compatibility of pure nix without flake-parts

### DIFF
--- a/compat.nix
+++ b/compat.nix
@@ -9,21 +9,25 @@
 {
   flake.configure =
     {
-      localFlake,
       nodes,
       cache ? "./secrets/cache",
       identity,
       extraRecipients ? [ ],
+      systems ? [
+        "x86_64-linux"
+        "aarch64-linux"
+        "riscv64-linux"
+      ],
     }:
     let
       inherit (inputs.nixpkgs) lib;
     in
     {
-      # for nixosSystem
+      # for nixosSystem finding the cache location
       inherit cache;
 
-      app = lib.mapAttrs (
-        system: config':
+      app = lib.genAttrs systems (
+        system:
         lib.genAttrs
           [
             "renc"
@@ -45,6 +49,6 @@
               package = self.packages.${system}.default;
             }
           )
-      ) localFlake.allSystems;
+      );
     };
 }

--- a/doc/pure-nix-config.md
+++ b/doc/pure-nix-config.md
@@ -11,19 +11,19 @@ The option is identical to [flakeModule](./flake-module.md), but different way t
 ```nix
 vaultix = inputs.vaultix.configure {
 
-  localFlake = self; # different from flakeModule way
-
-  # identical
+  # identical with flake-parts way
   nodes = self.nixosConfigurations;
   identity = self + "/age-yubikey-identity-deadbeef.txt.pub";
   extraRecipients = [ ];
   cache = "./secret/.cache";
+  # generating `outputs.vaultix.app.${system}.*`
+  systems = ["x86_64-linux","aarch64-linux"];
 };
 ```
 
 ---
 
-In this way your flake will looks like:
+Overview of flake in this configuration:
 
 ```nix
 {
@@ -49,8 +49,6 @@ In this way your flake will looks like:
       # ...
     };
     vaultix = vaultix.configure {
-    
-      localFlake = self; # different from flakeModule way
     
       # identical with flakeModule way
       nodes = self.nixosConfigurations;

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
           [
             flake-parts.flakeModules.easyOverlay
             flake-parts.flakeModules.partitions
-            ./compatible.nix
+            ./compat.nix
           ];
         systems = [
           "x86_64-linux"


### PR DESCRIPTION
`allSystems` option is only available on flake-parts, changed to a different way of generating nix apps.

### Backward Comppacity

This change permanently removed the `localFlake` option from `configure` function since it had never been used.