### PR TITLE
Add extraPackages option for extra packages in edit/renc path

### DIFF
--- a/apps/edit.nix
+++ b/apps/edit.nix
@@ -3,14 +3,19 @@
   package,
   identity,
   extraRecipients,
+  extraPackages,
   ...
 }:
 let
   inherit (pkgs) writeShellScriptBin;
-  inherit (pkgs.lib) concatStringsSep;
+  inherit (pkgs.lib) concatStringsSep makeBinPath;
 
   bin = pkgs.lib.getExe package;
   recipientsArg = concatStringsSep " " (map (n: "--recipient ${n}") extraRecipients);
+  pathPrefix = makeBinPath extraPackages;
 
 in
-writeShellScriptBin "edit-secret" "${bin} edit --identity ${identity} ${recipientsArg} $1"
+writeShellScriptBin "edit-secret" ''
+  export PATH=${pathPrefix}:$PATH
+  ${bin} edit --identity ${identity} ${recipientsArg} $1
+''

--- a/apps/renc.nix
+++ b/apps/renc.nix
@@ -5,11 +5,12 @@
   package,
   identity,
   cache,
+  extraPackages,
   ...
 }:
 let
   inherit (pkgs) writeShellScriptBin;
-  inherit (lib) concatStringsSep attrValues;
+  inherit (lib) concatStringsSep attrValues makeBinPath;
   bin = pkgs.lib.getExe package;
 
   profilesArgs = concatStringsSep " " (
@@ -34,5 +35,10 @@ let
 
   rencCmds = "${bin} ${profilesArgs} renc --identity ${identity} --cache ${cache}";
 
+  pathPrefix = makeBinPath extraPackages;
+
 in
-writeShellScriptBin "renc" rencCmds
+writeShellScriptBin "renc" ''
+  export PATH=${pathPrefix}:$PATH
+  ${rencCmds}
+''

--- a/compat.nix
+++ b/compat.nix
@@ -13,6 +13,7 @@
       cache ? "./secrets/cache",
       identity,
       extraRecipients ? [ ],
+      extraPackages ? [ ],
       systems ? [
         "x86_64-linux"
         "aarch64-linux"
@@ -40,6 +41,7 @@
                 nodes
                 identity
                 extraRecipients
+                extraPackages
                 cache
                 lib
                 ;

--- a/doc/flake-module.md
+++ b/doc/flake-module.md
@@ -29,6 +29,7 @@ flake-parts.lib.mkFlake { inherit inputs; } (
         # extraRecipients = [ ];            # default, optional
         # cache = "./secrets/cache";        # default, optional
         # nodes = self.nixosConfigurations; # default, optional
+        # extraPackages = [ ];              # default, optional
         identity = "/somewhere/age-yubikey-identity-deadbeef.txt";
       };
     };
@@ -91,6 +92,12 @@ Age recipients that used as backup keys. Any of them can decrypt all secrets, ju
 This option only takes effect after you finish [editing](/vaultix/nix-apps.html#edit) the secret file.
 In other words, changes to this value will not dynamically propagate to existing secrets.
 A single-line command to update all secrets globally with this option is currently unsupported
+
+### extraPackages
+
++ type: `list of package`
+
+Extra packages to be added to edit/renc's PATH. For example, pkgs.age-plugin-yubikey can be added when using yubikey with edit/renc.
 
 ### cache
 

--- a/doc/pure-nix-config.md
+++ b/doc/pure-nix-config.md
@@ -15,6 +15,7 @@ vaultix = inputs.vaultix.configure {
   nodes = self.nixosConfigurations;
   identity = self + "/age-yubikey-identity-deadbeef.txt.pub";
   extraRecipients = [ ];
+  extraPackages = [ ];
   cache = "./secret/.cache";
   # generating `outputs.vaultix.app.${system}.*`
   systems = ["x86_64-linux","aarch64-linux"];
@@ -54,6 +55,7 @@ Overview of flake in this configuration:
       nodes = self.nixosConfigurations;
       identity = self + "/age-yubikey-identity-deadbeef.txt.pub";
       extraRecipients = [ ];
+      extraPackages = [ ];
       cache = "./secret/.cache";
     };
   };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -64,6 +64,14 @@ in
                 to decrypt all secrets.
               '';
             };
+            extraPackages = mkOption {
+              type = with types; listOf package;
+              default = [ ];
+              example = lib.literalExpression "[ pkgs.age-plugin-yubikey ]";
+              description = ''
+                Set of extra packages like age plugins to be added in edit/renc's path.
+              '';
+            };
             app = mkOption {
               type = types.lazyAttrsOf (types.lazyAttrsOf types.package);
               default = lib.mapAttrs (
@@ -81,6 +89,7 @@ in
                         identity
                         extraRecipients
                         cache
+                        extraPackages
                         ;
                       inherit (config'.vaultix) pkgs;
                       inherit lib;


### PR DESCRIPTION
New option allows age-plugin-yubikey or other plugins to be on command's PATH.