### PR TITLE
Add pinentryPackage option to allow renc/edit use different pinentry program

### DIFF
--- a/apps/edit.nix
+++ b/apps/edit.nix
@@ -4,18 +4,20 @@
   identity,
   extraRecipients,
   extraPackages,
+  pinentryPackage,
   ...
 }:
 let
   inherit (pkgs) writeShellScriptBin;
-  inherit (pkgs.lib) concatStringsSep makeBinPath;
+  inherit (pkgs.lib) concatStringsSep makeBinPath optionalString getExe;
 
-  bin = pkgs.lib.getExe package;
+  bin = getExe package;
   recipientsArg = concatStringsSep " " (map (n: "--recipient ${n}") extraRecipients);
   pathPrefix = makeBinPath extraPackages;
 
 in
 writeShellScriptBin "edit-secret" ''
   export PATH=${pathPrefix}:$PATH
+  ${optionalString (pinentryPackage != null) "export PINENTRY_PROGRAM=${getExe pinentryPackage}"}
   ${bin} edit --identity ${identity} ${recipientsArg} $1
 ''

--- a/apps/renc.nix
+++ b/apps/renc.nix
@@ -6,6 +6,7 @@
   identity,
   cache,
   extraPackages,
+  pinentryPackage,
   ...
 }:
 let
@@ -15,8 +16,10 @@ let
     attrValues
     makeBinPath
     throwIfNot
+    optionalString
+    getExe
     ;
-  bin = pkgs.lib.getExe package;
+  bin = getExe package;
 
   profilesArgs = concatStringsSep " " (
     map (
@@ -53,5 +56,6 @@ let
 in
 writeShellScriptBin "renc" ''
   export PATH=${pathPrefix}:$PATH
+  ${optionalString (pinentryPackage != null) "export PINENTRY_PROGRAM=${getExe pinentryPackage}"}
   ${rencCmds}
 ''

--- a/compat.nix
+++ b/compat.nix
@@ -15,6 +15,7 @@
       identity,
       extraRecipients ? [ ],
       extraPackages ? [ ],
+      pinentryPackage ? null,
       systems ? [
         "x86_64-linux"
         "aarch64-linux"
@@ -43,6 +44,7 @@
                 identity
                 extraRecipients
                 extraPackages
+                pinentryPackage
                 cache
                 lib
                 ;

--- a/doc/flake-module.md
+++ b/doc/flake-module.md
@@ -31,6 +31,7 @@ flake-parts.lib.mkFlake { inherit inputs; } (
         # defaultSecretDirectory = "./secrets";  # default, optional
         # nodes = self.nixosConfigurations;      # default, optional
         # extraPackages = [ ];                   # default, optional
+        # pinentryPackage = null;                # default, optional
         identity = "/path/to/age-yubikey-identity-deadbeef.txt";
       };
     };
@@ -99,6 +100,14 @@ A single-line command to update all secrets globally with this option is current
 + type: `list of package`
 
 Extra packages to be added to edit/renc's PATH. For example, pkgs.age-plugin-yubikey can be added when using yubikey with edit/renc.
+
+### pinentryPackage
+
++ type: `nullable package`
+
+Which pinentry interface to use. If not `null`, the path to the mainProgram
+as defined in the package’s meta attributes will be set to PINENTRY_PROGRAM
+environment variable picked up by edit/renc command.
 
 ### cache
 

--- a/doc/flake-module.md
+++ b/doc/flake-module.md
@@ -103,7 +103,7 @@ Extra packages to be added to edit/renc's PATH. For example, pkgs.age-plugin-yub
 
 ### pinentryPackage
 
-+ type: `nullable package`
++ type: `null or package`
 
 Which pinentry interface to use. If not `null`, the path to the mainProgram
 as defined in the package’s meta attributes will be set to PINENTRY_PROGRAM

--- a/doc/pure-nix-config.md
+++ b/doc/pure-nix-config.md
@@ -16,6 +16,7 @@ vaultix = inputs.vaultix.configure {
   identity = self + "/age-yubikey-identity-deadbeef.txt.pub";
   extraRecipients = [ ];
   extraPackages = [ ];
+  pinentryPackage = null;
   cache = "./secret/.cache";
   # generating `outputs.vaultix.app.${system}.*`
   systems = ["x86_64-linux","aarch64-linux"];
@@ -56,6 +57,7 @@ Overview of flake in this configuration:
       identity = self + "/age-yubikey-identity-deadbeef.txt.pub";
       extraRecipients = [ ];
       extraPackages = [ ];
+      pinentryPackage = null;
       cache = "./secret/.cache";
     };
   };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -9,6 +9,7 @@ vaultixFlake:
 let
   inherit (lib)
     mkOption
+    mkPackageOption
     types
     ;
 
@@ -94,6 +95,15 @@ in
                 Set of extra packages like age plugins to be added in edit/renc's path.
               '';
             };
+            pinentryPackage = mkPackageOption config.vaultix.pkgs "pinentry-qt" {
+              nullable = true;
+              default = null;
+              extraDescription = ''
+                Which pinentry interface to use. If not `null`, the path to the mainProgram
+                as defined in the package’s meta attributes will be set to PINENTRY_PROGRAM
+                environment variable picked up by edit/renc command.
+                '';
+            };
             app = mkOption {
               type = types.lazyAttrsOf (types.lazyAttrsOf types.package);
               default = lib.mapAttrs (
@@ -112,6 +122,7 @@ in
                         extraRecipients
                         cache
                         extraPackages
+                        pinentryPackage
                         ;
                       inherit (config'.vaultix) pkgs;
                       inherit lib;


### PR DESCRIPTION
Same as https://search.nixos.org/options?channel=unstable&show=programs.gnupg.agent.pinentryPackage&from=0&size=50&sort=relevance&type=packages&query=pinentryPackage

pinentry-rs will pick up PINENTRY_PROGRAM 
as documented by rage https://github.com/str4d/rage?tab=readme-ov-file#passphrases