### PR TITLE
Implement prefetch mode

### DIFF
--- a/compat.nix
+++ b/compat.nix
@@ -10,7 +10,7 @@
   flake.configure =
     {
       nodes,
-      cache ? "./secrets/cache",
+      cache ? "/tmp/vaultix.\"$UID\"",
       defaultSecretDirectory ? "./secrets",
       identity,
       extraRecipients ? [ ],

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -21,14 +21,35 @@ in
         type = types.submodule (submod: {
           options = {
             cache = mkOption {
-              type = types.addCheck types.str (s: (builtins.substring 0 1 s) == ".") // {
-                description = "path string relative to flake root";
+              type = types.str // {
+                description = "path string relative to flake root, or absolute path string.";
               };
-              default = "./secrets/cache";
-              defaultText = lib.literalExpression "./secrets/cache";
+              default = "/tmp/vaultix.\"$UID\"";
+              defaultText = lib.literalExpression "/tmp/vaultix.\"$UID\"";
               description = ''
                 `path str` that relative to flake root, used for storing host public key
-                re-encrypted secrets.
+                re-encrypted secrets. If this is not set or is absolute path string,
+                prefetch mode will be automatically enabled.
+
+                Default is the path under /tmp. Could be bash expression resulting in a single
+                string.
+
+                example: "\"\$\{XDG_CACHE_HOME:=$HOME/.cache}/vaultix\""
+              '';
+            };
+            storageLocation = mkOption {
+              type = types.nullOr (
+                types.addCheck types.str (s: (builtins.substring 0 1 s) == ".")
+                // {
+                  description = "path string relative to flake root";
+                }
+              );
+              default = null;
+              defaultText = lib.literalExpression "null";
+              description = ''
+                null or `path str` that relative to flake root, used for storing host public key
+                re-encrypted secrets. If this is not `null`, host re-encrypted secret will be
+                stored in your configuration repo.
               '';
             };
             nodes = mkOption {
@@ -102,7 +123,7 @@ in
                 Which pinentry interface to use. If not `null`, the path to the mainProgram
                 as defined in the package’s meta attributes will be set to PINENTRY_PROGRAM
                 environment variable picked up by edit/renc command.
-                '';
+              '';
             };
             app = mkOption {
               type = types.lazyAttrsOf (types.lazyAttrsOf types.package);


### PR DESCRIPTION

Resolve #36 #37 #38


To store all secrets in a directory outside of the git repo:

1.  During the `renc` process, the secrets must be readable through the output of `nix eval`. (pure)
2.  During deployment, the `host secrets`[^1] must be findable within the Nix store. This is because:
    a. Deployments must be managed by Nix, and any artifact deployed by Nix must reside in the store.
    b. Likewise, when deploying to a target machine, the `host secrets` must already exist on that target before the activation script is run.

To meet condition #2, the old implementation requires `host secrets` to be located within the configuration directory. This is handled by the existing `cache` mechanism, which copies them to the Nix store at evaluation time using `cacheInStore`.

This PR introduces a new solution. It adds the `host secrets` generated by the `renc` command to the Nix store in advance (a "prefetch" step). The resulting store path string is then saved in the repository, which allows it to be loaded purely during flake eval. The saved path file will be automatically committed to keep the git worktree clean.

This new implementation will support placing both `ident secrets` and `host secrets` in paths outside the configuration repository. This approach mitigates the "harvest now, decrypt later" security risk and prevents the git history from being bloated by diffs from repeated `renc` operations.

The plan is to maintain forward compatibility. The existing `cache` option will be deprecated and replaced by `cache` option (`nullOr str`, where `str` is relative or abs (i.e. outside git repo) path str), which will be used to determine if the new prefetch mode should be enabled.


# TODOs

- [ ] Refactor option `cache`
- [ ] Add option `commitMessage`(`nullOr lines`)
- [ ] Refactor `cacheInStore` mechanism
- [ ] implement auto commit after renc

[^1]: `host secrets`: age secrets encrypted by openssh host public key.
[^2]: `ident secrets`: age secrets encrypted by the identity.