### PR TITLE
Use stable toolchain and reduce lockfile size

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -145,28 +145,6 @@
         "crane": "crane",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781061510,
-        "narHash": "sha256-tVuGHgt/TsWu1rUAqEL+eWRIJJHtiPE2+yQ63b+/WTU=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "d286e9691bb03045febbf8304a658eab1487d1b5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -31,25 +31,11 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1778716662,
@@ -102,24 +88,9 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat",
+        "flake-compat": [],
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
@@ -145,6 +116,7 @@
         "crane": "crane",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,18 @@
   description = "Vaultix";
 
   inputs = {
-    flake-parts.url = "github:hercules-ci/flake-parts";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     crane.url = "github:ipetkov/crane";
     pre-commit-hooks = {
       url = "github:cachix/git-hooks.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
+      inputs = {
+        flake-compat.follows = "";
+        nixpkgs.follows = "nixpkgs";
+      };
     };
     advisory-db = {
       url = "github:rustsec/advisory-db";

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,6 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     crane.url = "github:ipetkov/crane";
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     pre-commit-hooks = {
       url = "github:cachix/git-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -80,52 +76,25 @@
             ...
           }:
           let
-            target = (pkgs.lib.systems.elaborate system).config;
-            mkOverriddenToolchain =
-              scale:
-              scale.override {
-                extensions = [ "rust-src" ];
-                targets = [ target ];
-              };
-            mkCraneLib = toolchain: (crane.mkLib pkgs).overrideToolchain toolchain;
-            releaseToolChain = mkOverriddenToolchain pkgs.rust-bin.nightly.latest.minimal;
-            releaseCraneLib = mkCraneLib releaseToolChain;
-            devCraneLib = mkCraneLib (mkOverriddenToolchain pkgs.rust-bin.nightly.latest.complete);
-            inherit (releaseCraneLib) buildPackage;
+            craneLib = crane.mkLib pkgs;
+            inherit (craneLib) buildPackage;
+            src = craneLib.cleanCargoSource ./.;
 
             commonArgs = {
-              inherit src cargoVendorDir;
+              inherit src;
               nativeBuildInputs = [
                 pkgs.rustPlatform.bindgenHook
               ];
               strictDeps = true;
-              cargoExtraArgs = ''-Z build-std -Z build-std-features="optimize_for_size" --target ${target}'';
             };
-            cargoVendorDir = releaseCraneLib.vendorMultipleCargoDeps {
-              inherit (releaseCraneLib.findCargoFiles src) cargoConfigs;
-              cargoLockList = [
-                ./Cargo.lock
-
-                # Unfortunately this approach requires IFD (import-from-derivation)
-                # otherwise Nix will refuse to read the Cargo.lock from our toolchain
-                # (unless we build with `--impure`).
-                #
-                # Another way around this is to manually copy the rustlib `Cargo.lock`
-                # to the repo and import it with `./path/to/rustlib/Cargo.lock` which
-                # will avoid IFD entirely but will require manually keeping the file
-                # up to date!
-                "${releaseToolChain.passthru.availableComponents.rust-src}/lib/rustlib/src/rust/library/Cargo.lock"
-              ];
-            };
-            cargoArtifacts = devCraneLib.buildDepsOnly commonArgs;
-            src = releaseCraneLib.cleanCargoSource ./.;
+            cargoVendorDir = craneLib.vendorCargoDeps { cargoLock = ./Cargo.lock; };
+            cargoArtifacts = craneLib.buildDepsOnly commonArgs;
           in
           {
             _module.args.pkgs = import inputs.nixpkgs {
               inherit system;
-              overlays = with inputs; [
-                rust-overlay.overlays.default
-                self.overlays.default
+              overlays = [
+                inputs.self.overlays.default
               ];
             };
             apps = {
@@ -140,10 +109,10 @@
                 commonArgs
                 // {
                   version =
-                    (releaseCraneLib.crateNameFromCargoToml { cargoToml = ./Cargo.toml; }).version
+                    (craneLib.crateNameFromCargoToml { cargoToml = ./Cargo.toml; }).version
                     + "+"
                     + self.shortRev or "dirty";
-                  inherit cargoArtifacts;
+                  inherit cargoArtifacts cargoVendorDir;
 
                   # next-test
                   doCheck = false;
@@ -170,7 +139,7 @@
               };
             };
 
-            devShells.default = devCraneLib.devShell {
+            devShells.default = craneLib.devShell {
               shellHook = config.pre-commit.installationScript;
               inputsFrom = [
                 pkgs.vaultix
@@ -187,20 +156,19 @@
 
             checks = {
               # Audit dependencies
-              crate-audit = devCraneLib.cargoAudit {
+              crate-audit = craneLib.cargoAudit {
                 inherit src advisory-db cargoVendorDir;
                 # RUSTSEC-2023-0071: Marvin Attack: potential key recovery through timing sidechannels
                 cargoAuditExtraArgs = "--ignore RUSTSEC-2023-0071";
               };
 
-              crate-nextest = devCraneLib.cargoNextest (
+              crate-nextest = craneLib.cargoNextest (
                 commonArgs
                 // {
                   inherit cargoArtifacts cargoVendorDir;
                   partitions = 1;
                   partitionType = "count";
                   cargoNextestPartitionsExtraArgs = "--no-tests=pass";
-                  withLlvmCov = true;
                 }
               );
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#![feature(iterator_try_collect)]
 use cmd::Args;
 use eyre::Result;
 use simple_logger::SimpleLogger;

--- a/src/util/makeup.rs
+++ b/src/util/makeup.rs
@@ -71,7 +71,7 @@ impl<'a> RencInstance<'a> {
                                     }
                                     Ok((v, *k))
                                 })
-                                .try_collect()
+                                .collect::<Result<DashMap<_, _>, eyre::ErrReport>>()
                         }) {
                         Ok(o) => o,
                         e @ Err(_) => {

--- a/src/util/secmap.rs
+++ b/src/util/secmap.rs
@@ -266,7 +266,7 @@ impl<'a> RencData<'a, InStore> {
                     })
                     .map(|i| (k.0, i.inner()))
             })
-            .try_collect::<HashMap<&'a Secret, Vec<u8>>>()
+            .collect::<Result<HashMap<&'a Secret, Vec<u8>>, _>>()
     }
 }
 


### PR DESCRIPTION
this PR drops `rust-overlay` and removes nightly Rust dependencies (`#![feature(iterator_try_collect)]`) so `vaultix` can be built using stable toolchain

- drops the heavy nightly toolchain download and reduces dependencies to fetch
- `llvm-cov` is no longer available for test coverage