### PR TITLE
move advisory-db and checks to dev partition

### DIFF
--- a/dev/checks.nix
+++ b/dev/checks.nix
@@ -1,0 +1,48 @@
+{
+  inputs,
+  self,
+  ...
+}:
+{
+  perSystem =
+    {
+      pkgs,
+      ...
+    }:
+    let
+      craneLib = inputs.crane.mkLib pkgs;
+      src = craneLib.cleanCargoSource self;
+
+      commonArgs = {
+        inherit src;
+        nativeBuildInputs = [
+          pkgs.rustPlatform.bindgenHook
+        ];
+        strictDeps = true;
+      };
+      cargoVendorDir = craneLib.vendorCargoDeps { cargoLock = self + "/Cargo.lock"; };
+      cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+    in
+    {
+      checks = {
+        # Audit dependencies
+        crate-audit = craneLib.cargoAudit {
+          inherit src cargoVendorDir;
+          advisory-db = inputs.advisory-db;
+          # RUSTSEC-2023-0071: Marvin Attack: potential key recovery through timing sidechannels
+          # https://github.com/RustCrypto/RSA/issues/626
+          cargoAuditExtraArgs = "--ignore RUSTSEC-2023-0071";
+        };
+
+        crate-nextest = craneLib.cargoNextest (
+          commonArgs
+          // {
+            inherit cargoArtifacts cargoVendorDir;
+            partitions = 1;
+            partitionType = "count";
+            cargoNextestPartitionsExtraArgs = "--no-tests=pass";
+          }
+        );
+      };
+    };
+}

--- a/dev/flake.lock
+++ b/dev/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "advisory-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782467904,
+        "narHash": "sha256-2ROADxDdmTMFV+jbwPbCU33qNZIO+WRcpUXmoQGLTLI=",
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "rev": "e69927bf37afb7707575bc95aff6a9ef3f2534fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rustsec",
+        "repo": "advisory-db",
+        "type": "github"
+      }
+    },
     "disko": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -15,43 +31,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "disko",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -71,63 +50,10 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1730741070,
-        "narHash": "sha256-edm8WG19kWozJ/GqyYx2VjW99EdhjKwbY3ZwdlPAAlo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d063c1dd113c91ab27959ba540c0d9753409edf3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1730768919,
-        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgs-stable": "nixpkgs-stable"
-      },
-      "locked": {
-        "lastModified": 1731363552,
-        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "disko": "disko",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "advisory-db": "advisory-db",
+        "disko": "disko"
       }
     }
   },

--- a/dev/flake.nix
+++ b/dev/flake.nix
@@ -7,6 +7,10 @@
       url = "github:nix-community/disko";
     };
 
+    advisory-db = {
+      url = "github:rustsec/advisory-db";
+      flake = false;
+    };
   };
 
   outputs = _: { };

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,5 @@
 {
   "nodes": {
-    "advisory-db": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1781072009,
-        "narHash": "sha256-WhB6bdXmPVmuFPRLFDz2NTdW/oAwni7lmhIXJ3YWRpQ=",
-        "owner": "rustsec",
-        "repo": "advisory-db",
-        "rev": "02c8054e58f23460910a494cc1b068752338392e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rustsec",
-        "repo": "advisory-db",
-        "type": "github"
-      }
-    },
     "crane": {
       "locked": {
         "lastModified": 1780532242,
@@ -112,7 +96,6 @@
     },
     "root": {
       "inputs": {
-        "advisory-db": "advisory-db",
         "crane": "crane",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -15,10 +15,6 @@
         nixpkgs.follows = "nixpkgs";
       };
     };
-    advisory-db = {
-      url = "github:rustsec/advisory-db";
-      flake = false;
-    };
   };
 
   outputs =
@@ -26,7 +22,6 @@
       flake-parts,
       self,
       crane,
-      advisory-db,
       ...
     }:
     flake-parts.lib.mkFlake { inherit inputs; } (
@@ -55,6 +50,7 @@
             imports = [
               flakeModules.default
               ./dev/test.nix
+              ./dev/checks.nix
             ];
           };
         };
@@ -160,24 +156,6 @@
               ];
             };
 
-            checks = {
-              # Audit dependencies
-              crate-audit = craneLib.cargoAudit {
-                inherit src advisory-db cargoVendorDir;
-                # RUSTSEC-2023-0071: Marvin Attack: potential key recovery through timing sidechannels
-                cargoAuditExtraArgs = "--ignore RUSTSEC-2023-0071";
-              };
-
-              crate-nextest = craneLib.cargoNextest (
-                commonArgs
-                // {
-                  inherit cargoArtifacts cargoVendorDir;
-                  partitions = 1;
-                  partitionType = "count";
-                  cargoNextestPartitionsExtraArgs = "--no-tests=pass";
-                }
-              );
-            };
           };
         flake = {
           inherit flakeModules;


### PR DESCRIPTION
Move advisory-db input from the main flake into dev/flake.nix and extract checks (crate-audit, crate-nextest) into dev/checks.nix, imported by the dev partition module.

This removes advisory-db from the main flake.lock so that consumers who only use the vaultix package or NixOS module don't need to fetch it. All checks remain functional via the dev partition.