### PR TITLE
refactor(flake-module): move extraPackages from flake level to perSystem

### DIFF
--- a/doc/flake-module.md
+++ b/doc/flake-module.md
@@ -30,9 +30,14 @@ flake-parts.lib.mkFlake { inherit inputs; } (
         # cache = "./secrets/cache";             # default, optional
         # defaultSecretDirectory = "./secrets";  # default, optional
         # nodes = self.nixosConfigurations;      # default, optional
-        # extraPackages = [ ];                   # default, optional
         # pinentryPackage = null;                # default, optional
         identity = "/path/to/age-yubikey-identity-deadbeef.txt";
+      };
+    };
+
+    perSystem = { pkgs, ... }: {
+      vaultix = {
+        # extraPackages = [ pkgs.age-plugin-yubikey ];  # default, optional
       };
     };
   });
@@ -103,12 +108,15 @@ A single-line command to update all secrets globally with this option is current
 
 Extra packages to be added to edit/renc's PATH. For example, pkgs.age-plugin-yubikey can be added when using yubikey with edit/renc.
 
+> [!NOTE]
+> This is a **perSystem** option, set under `perSystem.vaultix.extraPackages`.
+
 ### pinentryPackage
 
 + type: `null or package`
 
 Which pinentry interface to use. If not `null`, the path to the mainProgram
-as defined in the package’s meta attributes will be set to PINENTRY_PROGRAM
+as defined in the package's meta attributes will be set to PINENTRY_PROGRAM
 environment variable picked up by edit/renc command.
 
 ### cache

--- a/doc/flake-module.md
+++ b/doc/flake-module.md
@@ -30,7 +30,6 @@ flake-parts.lib.mkFlake { inherit inputs; } (
         # cache = "./secrets/cache";             # default, optional
         # defaultSecretDirectory = "./secrets";  # default, optional
         # nodes = self.nixosConfigurations;      # default, optional
-        # pinentryPackage = null;                # default, optional
         identity = "/path/to/age-yubikey-identity-deadbeef.txt";
       };
     };
@@ -38,6 +37,7 @@ flake-parts.lib.mkFlake { inherit inputs; } (
     perSystem = { pkgs, ... }: {
       vaultix = {
         # extraPackages = [ pkgs.age-plugin-yubikey ];  # default, optional
+        # pinentryPackage = null;                       # default, optional
       };
     };
   });
@@ -118,6 +118,9 @@ Extra packages to be added to edit/renc's PATH. For example, pkgs.age-plugin-yub
 Which pinentry interface to use. If not `null`, the path to the mainProgram
 as defined in the package's meta attributes will be set to PINENTRY_PROGRAM
 environment variable picked up by edit/renc command.
+
+> [!NOTE]
+> This is a **perSystem** option, set under `perSystem.vaultix.pinentryPackage`.
 
 ### cache
 

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -87,14 +87,6 @@ in
                 to decrypt all secrets.
               '';
             };
-            extraPackages = mkOption {
-              type = with types; listOf package;
-              default = [ ];
-              example = lib.literalExpression "[ pkgs.age-plugin-yubikey ]";
-              description = ''
-                Set of extra packages like age plugins to be added in edit/renc's path.
-              '';
-            };
             pinentryPackage = mkPackageOption config.vaultix.pkgs "pinentry-qt" {
               nullable = true;
               default = null;
@@ -121,10 +113,9 @@ in
                         identity
                         extraRecipients
                         cache
-                        extraPackages
                         pinentryPackage
                         ;
-                      inherit (config'.vaultix) pkgs;
+                      inherit (config'.vaultix) pkgs extraPackages;
                       inherit lib;
                       package = vaultixFlake.packages.${system}.default;
                     }
@@ -161,6 +152,14 @@ in
             defaultText = lib.literalExpression "pkgs";
             description = ''
               pkgs that passed into vaultix apps.
+            '';
+          };
+          extraPackages = mkOption {
+            type = with types; listOf package;
+            default = [ ];
+            example = lib.literalExpression "[ pkgs.age-plugin-yubikey ]";
+            description = ''
+              Set of extra packages like age plugins to be added in edit/renc's path.
             '';
           };
         };

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -87,15 +87,6 @@ in
                 to decrypt all secrets.
               '';
             };
-            pinentryPackage = mkPackageOption config.vaultix.pkgs "pinentry-qt" {
-              nullable = true;
-              default = null;
-              extraDescription = ''
-                Which pinentry interface to use. If not `null`, the path to the mainProgram
-                as defined in the package’s meta attributes will be set to PINENTRY_PROGRAM
-                environment variable picked up by edit/renc command.
-              '';
-            };
             app = mkOption {
               type = types.lazyAttrsOf (types.lazyAttrsOf types.package);
               default = lib.mapAttrs (
@@ -113,9 +104,8 @@ in
                         identity
                         extraRecipients
                         cache
-                        pinentryPackage
                         ;
-                      inherit (config'.vaultix) pkgs extraPackages;
+                      inherit (config'.vaultix) pkgs extraPackages pinentryPackage;
                       inherit lib;
                       package = vaultixFlake.packages.${system}.default;
                     }
@@ -160,6 +150,15 @@ in
             example = lib.literalExpression "[ pkgs.age-plugin-yubikey ]";
             description = ''
               Set of extra packages like age plugins to be added in edit/renc's path.
+            '';
+          };
+          pinentryPackage = mkPackageOption pkgs "pinentry-qt" {
+            nullable = true;
+            default = null;
+            extraDescription = ''
+              Which pinentry interface to use. If not `null`, the path to the mainProgram
+              as defined in the package’s meta attributes will be set to PINENTRY_PROGRAM
+              environment variable picked up by edit/renc command.
             '';
           };
         };


### PR DESCRIPTION
Packages are system-specific derivations, so they belong under perSystem where pkgs is naturally available. This avoids users having to hardcode their system architecture to reference packages.

fix #59 

Along with `extraPackages`, I also moved `pinentryPackage` from `options.flake.vaultix` to `options.perSystem.vaultix` for consistency. This eliminates the previous cross-level reference `config.vaultix.pkgs` (a perSystem option) being accessed from a flake-level option definition, replacing it with the natural `mkPackageOption pkgs "pinentry-qt"`. If the maintainers consider this unnecessary, feel free to drop this commit.