### PR TITLE
feat(ux): improve yubikey UX

### DIFF
--- a/src/parser/identity.rs
+++ b/src/parser/identity.rs
@@ -235,7 +235,7 @@ impl TryInto<ParsedIdentity> for RawIdentity {
                 .map_err(|e| eyre!("import from identity file {identity_filename} error: {e}"));
 
             #[cfg(feature = "plugin")]
-            let identity_file = identity_file_result.map(|i| i.with_callbacks(UiCallbacks));
+            let identity_file = identity_file_result.map(|i| i.with_callbacks(UiCallbacks::new()));
             #[cfg(not(feature = "plugin"))]
             let identity_file = identity_file_result;
 
@@ -266,7 +266,7 @@ impl TryInto<ParsedIdentity> for RawIdentity {
                     return Err(eyre!("unsupported key: {identity_filename}, {k:#?}"));
                 }
                 Ok(identity) => {
-                    let ident = Box::new(identity.clone().with_callbacks(UiCallbacks));
+                    let ident = Box::new(identity.clone().with_callbacks(UiCallbacks::new()));
                     match age::ssh::Recipient::try_from(identity).map(Box::new) {
                         Ok(recip) => return Ok(ParsedIdentity::from_exist(ident, recip)),
                         Err(e) => {

--- a/src/parser/recipient.rs
+++ b/src/parser/recipient.rs
@@ -36,7 +36,7 @@ impl TryInto<Box<dyn Recipient + Send>> for RecipString {
             let plugin_recip = recip_str
                 .parse::<plugin::Recipient>()
                 .map_err(|e| eyre!(e))?;
-            build_plugin_recip(&plugin_recip, UiCallbacks)
+            build_plugin_recip(&plugin_recip, UiCallbacks::new())
         }
 
         #[cfg(not(feature = "plugin"))]

--- a/src/util/callback.rs
+++ b/src/util/callback.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use age::secrecy::{ExposeSecret, SecretString};
 use age::Callbacks;
 use pinentry::{ConfirmationDialog, PassphraseInput};
@@ -5,8 +7,24 @@ use rpassword::prompt_password;
 use std::io;
 use subtle::ConstantTimeEq;
 
-#[derive(Clone, Copy)]
-pub struct UiCallbacks;
+#[derive(Clone)]
+pub struct UiCallbacks {
+    cached_passphrase: Arc<Mutex<Option<SecretString>>>,
+}
+
+impl UiCallbacks {
+    pub fn new() -> Self {
+        Self {
+            cached_passphrase: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl Default for UiCallbacks {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Callbacks for UiCallbacks {
     fn display_message(&self, message: &str) {
@@ -24,7 +42,13 @@ impl Callbacks for UiCallbacks {
     }
 
     fn request_passphrase(&self, description: &str) -> Option<SecretString> {
-        read_secret(description, "input password:", None).ok()
+        let mut cache = self.cached_passphrase.lock().ok()?;
+        if let Some(ref cached) = *cache {
+            return Some(cached.clone());
+        }
+        let passphrase = read_secret(description, "input password:", None).ok()?;
+        *cache = Some(passphrase.clone());
+        Some(passphrase)
     }
 }
 fn confirm(query: &str, ok: &str, cancel: Option<&str>) -> pinentry::Result<bool> {

--- a/src/util/makeup.rs
+++ b/src/util/makeup.rs
@@ -135,13 +135,13 @@ impl<'a> RencInstance<'a> {
 
                         let buf = if let Some(o) = dst_ctt_map_ref
                             .get(inrepo_path)
-                            .and_then(|s| sec_plain_map.get(*s))
+                            .and_then(|sp| sec_plain_map.get(*sp))
                         {
                             o
                         } else {
                             res.lock().expect("must success").push(Err(eyre!(
-                                "The secret store MAY contains stuff encrypted by other identity: {inrepo_path}"
-                            )).wrap_err_with(||eyre!("Getting {:?} error", s)));
+                                "secret not decrypted for {inrepo_path}: it may be encrypted with a different identity"
+                            )));
                             return;
                         };
 

--- a/src/util/makeup.rs
+++ b/src/util/makeup.rs
@@ -55,8 +55,24 @@ impl<'a> RencInstance<'a> {
                         .get(h)
                         .wrap_err_with(|| eyre!("never"))
                         .and_then(|m| {
+                            let total = m.len();
                             m.iter()
-                                .map(|(k, v)| {
+                                .enumerate()
+                                .map(|(i, (k, v))| {
+                                    let kind = if sec_plain_map.contains_key(k) {
+                                        "reuse"
+                                    } else {
+                                        "decrypt"
+                                    };
+                                    info!(
+                                        "[{}/{}] {} {} for {}",
+                                        i + 1,
+                                        total,
+                                        kind,
+                                        k.file,
+                                        h.id()
+                                    );
+
                                     if sec_plain_map.contains_key(k) {
                                         return Ok((v, *k));
                                     }

--- a/src/util/makeup.rs
+++ b/src/util/makeup.rs
@@ -197,12 +197,15 @@ impl<'a> RencInstance<'a> {
 
         let last_res = res.lock().expect("never");
 
-        last_res.iter().for_each(|i| {
-            if let Err(e) = i {
-                error!("{e}");
-            }
-        });
+        let errs: Vec<_> = last_res.iter().filter_map(|i| i.as_ref().err()).collect();
+        for e in &errs {
+            error!("{e}");
+        }
 
-        Ok(())
+        if errs.is_empty() {
+            Ok(())
+        } else {
+            Err(eyre!("{} host(s) failed to re-encrypt", errs.len()))
+        }
     }
 }

--- a/src/util/makeup.rs
+++ b/src/util/makeup.rs
@@ -130,6 +130,7 @@ impl<'a> RencInstance<'a> {
                                     .wrap_err_with(|| eyre!("create host cache dir in repo failed"))
                             })
                         {
+                            error!("{e}");
                             res.lock().expect("doesn't matter now").push(Err(e));
                             return;
                         };
@@ -141,9 +142,11 @@ impl<'a> RencInstance<'a> {
                         {
                             o
                         } else {
+                            let e = eyre!("create cache file error: {inrepo_path}");
+                            error!("{e}");
                             res.lock()
                                 .expect("doesn't matter now")
-                                .push(Err(eyre!("create file error")));
+                                .push(Err(e));
                             return;
                         };
 
@@ -155,30 +158,36 @@ impl<'a> RencInstance<'a> {
                         {
                             o
                         } else {
-                            res.lock().expect("must success").push(Err(eyre!(
+                            let e = eyre!(
                                 "secret not decrypted for {inrepo_path}: it may be encrypted with a different identity"
-                            )));
+                            );
+                            error!("{e}");
+                            res.lock().expect("must success").push(Err(e));
                             return;
                         };
 
                         let ctt = match buf.clone().encrypt(iter::once(recip.as_ref())) {
                             Ok(o) => o,
-                            e @ Err(_) => {
+                            Err(e) => {
+                                error!("encrypt failed for {inrepo_path}: {e}");
                                 res.lock()
                                     .expect("doesn't matter now")
-                                    .push(e.map(|_| PathBuf::default()));
+                                    .push(Err(e));
                                 return;
                             }
                         };
 
-                        if target_file.write_all(ctt.inner().as_bytes()).is_err() {
+                        if let Err(e) = target_file.write_all(ctt.inner().as_bytes()) {
+                            let e = eyre!("write cache file failed: {e}");
+                            error!("{e}");
                             res.lock()
                                 .expect("doesn't matter now")
-                                .push(Err(eyre!("write cache file failed")))
-                        };
-                        res.lock()
-                            .expect("thread work end")
-                            .push(Ok(inrepo_path.path.clone()));
+                                .push(Err(e));
+                        } else {
+                            res.lock()
+                                .expect("thread work end")
+                                .push(Ok(inrepo_path.path.clone()));
+                        }
                     }
                 });
             });


### PR DESCRIPTION
This PR improve the UX:
 - Cache the PIN in-memory so you only type it once per run 
   This in-memory PIN caching is a pragmatic mitigation, not a structural fix. It is necessary because the stateless, short-lived nature of age plugins causes pcscd to terminate the session after each decryption, which instantly wipes the YubiKey's hardware PIV cache and breaks the "PIN match once" policy during batch operations. I fully accept your opinion on whether or not to take this mitigation measure. Alternatively, we could provide an option later in the project to configure whether to enable it?
   Reference: https://github.com/str4d/age-plugin-yubikey/issues/115#issuecomment-1426877356
   More information: `vaultix renc` calls `age::Decryptor::decrypt()` once per secret, each translated by the age crate into a separate plugin protocol `unwrap` message. `age-plugin-yubikey` calls `stub.connect()` on every `unwrap_file_keys` invocation, creating a fresh `Connection`; the `yubikey` crate's software-level `verify_pin(&[])` session state is lost with each new `Connection`, so `request_pin_if_necessary` cannot skip PIN prompts across messages, resulting in a PIN prompt for every file even with `PinPolicy::Once`. 
 - Show `[i/N] decrypt|reuse /path/secret for host` before each operation so you know what's happening
 - Log errors immediately instead of hiding them until the end
 - Return a non-zero exit code when re-encrypt fails

fix #60 